### PR TITLE
BUG: Reset redux state of selectedRequest when logging out

### DIFF
--- a/src/state/reducers/authenticationReducer.js
+++ b/src/state/reducers/authenticationReducer.js
@@ -10,9 +10,7 @@ const authenticationReducer = (state = initialState, action) => {
       };
     case "LOGOUT":
       return {
-        ...state,
-        authenticated: false,
-        uid: "",
+        ...initialState
       };
     default:
       return state;


### PR DESCRIPTION
[PT BUG](https://www.pivotaltracker.com/story/show/173450707)
Opting for full reset of state when logging out, as no state is used for visitor except to show specific request and that is fine to reset as well.
Was unable to recreate the bug, but this should cover it regardless.